### PR TITLE
Fix user email duplicates

### DIFF
--- a/service/user.js
+++ b/service/user.js
@@ -31,8 +31,9 @@ async function create (req, res) {
     let users = await User.find({});
     users = users.filter(user => user.email === email);
 
+    // User with the given email already exists, so return the user.
     if (users.length > 0) {
-        return res.status(400).json({ error: 'duplicate email' });
+        return res.status(200).json(users[0]);
     }
 
     const user = new User({


### PR DESCRIPTION
Issue #75 

Changes: 
- Fix user email duplicates
- If there is a duplicate email, it means the user is trying to login (e.g., not the first visit to the website), so return the user info. Otherwise, create a new user. 