### PR TITLE
Add order shipping address and implement rate and comment on seller 

### DIFF
--- a/controllers/user.js
+++ b/controllers/user.js
@@ -20,6 +20,10 @@ router.delete('/:id', (req, res, next) => userService.deleteById(req, res));
 
 router.delete('/', (req, res, next) => userService.deleteAll(req, res));
 
+router.put('/:buyer/rates', (req, res, next) => userService.rateUserById(req, res));
+
+router.put('/:buyer/comments', (req, res, next) => userService.commentUserById(req, res));
+
 router.put('/:id', (req, res, next) => userService.updateById(req, res));
 
 module.exports = router;

--- a/frontend/pfiniture/src/API/order-api.js
+++ b/frontend/pfiniture/src/API/order-api.js
@@ -30,10 +30,30 @@ export default class orderClient {
         }
     }
 
-    static async addToOrders({user, totalAmount, paymentType, furnitures}) {
+    static async addToOrders({seller, buyer, totalAmount, paymentType, furnitures}) {
         try {
             const response = axios.post(BASE_URL + `/api/v1/orders/`, 
-            {user, totalAmount, paymentType, furnitures});
+            {seller, buyer, totalAmount, paymentType, furnitures});
+            return response
+        } catch (e) {
+            console.log(e.message())
+        }
+    }
+
+    static async rateSeller({seller, rating, id}) {
+        try {
+            const response = axios.post(BASE_URL + `/api/v1/orders/${id}/rates`, 
+            {seller, rating});
+            return response
+        } catch (e) {
+            console.log(e.message())
+        }
+    }
+
+    static async commentSeller({seller, comment, id}) {
+        try {
+            const response = axios.post(BASE_URL + `/api/v1/orders/${id}/comments`, 
+            {seller, comment});
             return response
         } catch (e) {
             console.log(e.message())

--- a/models/order.js
+++ b/models/order.js
@@ -23,6 +23,28 @@ const orderSchema = new mongoose.Schema({
             type: String
         },
     ],
+    shippingAddress: {
+        address: {
+            required: true,
+            type: String
+        },
+        city: {
+            required: true,
+            type: String
+        },
+        province: {
+            required: true,
+            type: String
+        },
+        country: {
+            required: true,
+            type: String
+        },
+        postalCode: {
+            required: true,
+            type: String
+        }
+    }
 });
 
 orderSchema.set('toJSON', {

--- a/models/order.js
+++ b/models/order.js
@@ -1,7 +1,12 @@
 const mongoose = require('mongoose');
 
 const orderSchema = new mongoose.Schema({
-    user: {
+    seller: {
+        required: true,
+        type: mongoose.Schema.Types.ObjectId,
+        ref: 'User'
+    },
+    buyer: {
         required: true,
         type: mongoose.Schema.Types.ObjectId,
         ref: 'User'

--- a/models/user.js
+++ b/models/user.js
@@ -15,6 +15,29 @@ const userSchema = new mongoose.Schema({
             ref: 'Listing'
         }
     ],
+    ratedUsers: [
+        {
+            user: {
+                type: mongoose.Schema.Types.ObjectId,
+                ref: 'User'
+            },
+            rating: {
+                default: 0,
+                type: Number
+            }
+        }
+    ],
+    commentedUsers: [
+        {
+            user: {
+                type: mongoose.Schema.Types.ObjectId,
+                ref: 'User'
+            },
+            comment: {
+                type: String
+            }
+        }
+    ],
     rating: {
         default: 0,
         type: Number

--- a/service/order.js
+++ b/service/order.js
@@ -59,22 +59,34 @@ const deleteById = async (req, res) => {
 
 
 const create = async (req, res) => {
-    const { user, totalAmount, paymentType, furnitures} = req.body;
+    const { user, totalAmount, paymentType, furnitures, shippingAddress } = req.body;
     const userObject = await User.findById(user);
     if (userObject === null) {
         return res.status(404).json({ error: 'invalid id' });
     }
 
+    if (!user || !totalAmount || !paymentType || !furnitures || furnitures.length === 0 || !shippingAddress) {
+        return res.status(404).json({ error: 'bad request - cannot take null values' });
+    }
+
     console.log(userObject);
     console.log(paymentType);
     console.log(furnitures);
+    console.log(shippingAddress);
 
     const order = new Order({
         user: userObject,
         totalAmount: totalAmount,
-        paymentType: paymentType,
+        paymentType: paymentType.toLowerCase(),
         furnitures: furnitures,
-        orderDate: new Date()
+        orderDate: new Date(),
+        shippingAddress: {
+            address: shippingAddress.address.trim().toLowerCase(),
+            city: shippingAddress.city.trim().toLowerCase(),
+            province: shippingAddress.province.trim().toLowerCase(),
+            country: shippingAddress.country.trim().toLowerCase(),
+            postalCode: shippingAddress.postalCode.replace(/\s+/g, '').toLowerCase()
+        }
     });
 
     console.log(order);


### PR DESCRIPTION
Changes: 
- Order takes in `buyer, seller, shippingAddress`now **(note that `user` is replaced by both `buyer` and `seller`)**.
- `{
    "buyer": "61089d7106e6482f09f1a2d2",
    "seller": "6107996fd1d1014175a5c532",
    "furnitures": [
        "610530ec5baecd2136f1c63b"
    ],
    "totalAmount": 200,
    "paymentType": "Paypal",
    "shippingAddress": {
        "address": "12345 Main St",
        "city": "Vancouver", 
        "province": "BC",
        "country": "Canada", 
        "postalCode": "V1R 9F2"
    }
}
`

- User has `ratedUsers` and `commentedUsers` fields which are arrays of sellers that the current user (e.g., buyer) has commented and/or rated.  

- As buyers can always update their ratings and comments (e.g., reviews) on already reviewed/rated sellers, the values get updated and reflect on the seller as well. 

- The API endpoint to rate the seller: 
- `/api/v1/users/<buyer_id>/rates` with seller ID and rating are passed in request body: `{
    "seller": "61089d7106e6482f09f1a2d2",
    "rating": 4
}`.

- The API endpoint to comment on the seller: 
- `/api/v1/users/<buyer_id>/comments` with seller ID and comment are passed in request body: `{
    "seller": "61089d7106e6482f09f1a2d2",
    "comment": "Some test comment"
}`.

Tested with Postman