### PR TITLE
Add overallRating in User

### DIFF
--- a/models/user.js
+++ b/models/user.js
@@ -61,7 +61,10 @@ const userSchema = new mongoose.Schema({
             }
         }
     ],
-
+    overallRating: {
+        default: 0,
+        type: Number,
+    },
     location: {
         required: true,
         type: String

--- a/service/user.js
+++ b/service/user.js
@@ -241,6 +241,11 @@ const rateUserById = async (req, res) => {
         rating: (rating > 5) ? 5 : rating
     });
 
+    // Update the seller's overall rating.
+    newSellerObject.overallRating = newSellerObject.ratings.length === 0
+        ? 0
+        : newSellerObject.ratings.reduce((a, b) => a + b.rating, 0) / newSellerObject.ratings.length;
+
     User
         .findByIdAndUpdate(newSellerObject.id, newSellerObject, {new: true})
         .then(() => {


### PR DESCRIPTION
Changes: 
- Add the computed overallRating to the User, so that get user by ID returns User with overallRating field as well 
Example `{
    "listings": [],
    "overallRating": 3.5,
    "orders": [],
    "name": "Tester Three",
    "email": "testerthree@test.com",
    "location": "Langley",
    "ratedUsers": [],
    "commentedUsers": [],
    "ratings": [
        {
            "rating": 2,
            "_id": "61133524a17a0611ef00a326",
            "user": "6112970d02946e142d520505"
        },
        {
            "rating": 5,
            "_id": "611335cca17a0611ef00a39c",
            "user": "611296f002946e142d520501"
        }
    ],
    "comments": [
        {
            "_id": "611333dff7d06111b92faeb8",
            "user": "6112970d02946e142d520505",
            "comment": "Here is my new updated review"
        },
        {
            "_id": "61133544a17a0611ef00a336",
            "user": "611296f002946e142d520501",
            "comment": "My second awesome review!"
        }
    ],
    "id": "611333b9f7d06111b92faeaf"
}`